### PR TITLE
Fix to prevent the user removed yandexTranslateTagline

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
@@ -1359,7 +1359,7 @@ public class Form extends Activity
   private void showAboutApplicationNotification() {
     String title = "About This App";
     String tagline = "<p><small><em>Invented with MIT App Inventor<br>appinventor.mit.edu</em></small>";
-    String message = aboutScreen + tagline + yandexTranslateTagline;
+    String message = tagline + yandexTranslateTagline + aboutScreen;
     String buttonText ="Got it";
     Notifier.oneButtonAlert(this, message, title, buttonText);
   }


### PR DESCRIPTION
This prevents the use from removing the yandex Translate license statement if <!-- is entered
